### PR TITLE
[Port from ComplexVisual PR] Add Plot recipes for easy interaction with Plots.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/ComplexPortraits.jl
+++ b/src/ComplexPortraits.jl
@@ -3,7 +3,7 @@
 """
 module ComplexPortraits
 
-using Colors
+using Colors, RecipesBase
 
 """macro for importing the *huge* set of symbols."""
 macro import_huge()
@@ -21,7 +21,8 @@ macro import_huge()
                             cs_gridReIm, cs_gridReIm_logabs, cs_gridReIm_abs,
                             cs_stripes, cs_angle_abs_stripes,
                             cs_useImage,
-                            portrait
+                            portrait,
+                            phaseplot, phaseplot!, PhasePlot
   )
 end
 
@@ -36,7 +37,8 @@ macro import_normal()
                             cs_gridReIm, cs_gridReIm_logabs, cs_gridReIm_abs,
                             cs_stripes, cs_angle_abs_stripes,
                             cs_useImage,
-                            portrait
+                            portrait,
+                            phaseplot, phaseplot!, PhasePlot
   )
 end
 
@@ -67,6 +69,8 @@ function portrait(z_upperleft, z_lowerright, f;
     for y in LinRange(imag(z_upperleft), imag(z_lowerright), no_pixels[1]),
         x in LinRange(real(z_upperleft), real(z_lowerright), no_pixels[2])]
 end
+
+include("./plotrecipes.jl")
 
 end
 

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,0 +1,61 @@
+@userplot PhasePlot
+# args:  z_upperleft::Complex, z_lowerright::Complex, f::Function
+@recipe function plot_portrait(P::PhasePlot; 
+                               no_pixels=(600,600), point_color=cs_j(),
+                               no_ticks=7, ticks_sigdigits=2)
+  length(no_ticks) == 1 && (no_ticks = (no_ticks, no_ticks))
+  z_upperleft, z_lowerright, f = P.args[1:3]            
+  img = portrait(z_upperleft, z_lowerright, f;
+                 no_pixels=no_pixels, point_color=point_color);
+
+  seriestype := :heatmap
+  xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
+             round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[1]), sigdigits=ticks_sigdigits))
+  yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
+             round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[2]), sigdigits=ticks_sigdigits))
+
+  img
+end
+
+"""
+```
+phaseplot(z_upperleft, z_lowerright, f)
+```
+Convinience function, automatically adds ticks and creates a `Plot` object.
+
+Can be used in layouts. Examples:
+
+```
+using Plots, ComplexPortraits
+@ComplexPortraits.import_huge
+
+phaseplot(-2.0 + 2.0im, 2.0 - 2.0im, z -> z^2)
+
+phaseplot(-2.0 + 2.0im, 2.0 - 2.0im, z -> z^2;
+          no_pixels=(600, 600),
+          point_color=cs_j(),
+          no_ticks=(7, 7),
+          ticks_sigdigits=2)
+```
+
+Todo: hack colorbar plotattribute to show colorwheel.
+"""
+phaseplot;
+
+"""
+tests:
+function crop_to_circle!(A:Array; radius=0, background_color=RGB{Float64}(1.0,1.0,1.0))
+    m, n = size(A)
+    max_radius = min(m, n) / 2
+    center = [m/2, n/2]
+    (radius < 0 || radius > max_radius) && cv_error("plot image size too small. ", 
+                                                    "Maximum radius = ", max_radius)
+    radius == 0 && (radius = max_radius)
+
+    for i in Base.OneTo(m), j in Base.OneTo(n)
+        sum(([i, j] .- center).^2) * π > radius && (A[i, j] = background_color)
+    end
+
+    return A
+end
+"""


### PR DESCRIPTION
#### This is a port of the pull request in [ComplexVisual.jl](https://github.com/luchr/ComplexVisual.jl)

Plot recipes make a package 'just work' with Julia's `Plots` package. This is a very small addition that allows a user to harness the power + ease of use of `Plots` with their portraits. The two-line command 
```
using Plots, ComplexPortraits
ComplexPortraits.phaseplot(-2.0 + 2.0im, 2.0 - 2.0im, z -> exp(z) - z)
```
automatically calculates ticks, creates axes, and creates a `Plots.Plot` object. 

![plotrecipe](https://user-images.githubusercontent.com/74353857/117841782-9b3c2b80-b27d-11eb-91f4-d2702377adcc.png)

This can be used in layouts (i.e. if you want the phase portrait to be just one subplot in a larger figure), or it can be used to easily create animations using the `@animate` macro. 

Added dependency: `RecipesBase`. Julia's `RecipesBase` package is extremely small, barely 400 lines of code in total, but it allows any package to work with `Plots` out of the box. 

The full list of kwargs is:
```
 phaseplot(z_upperleft, z_lowerright, f;
           no_pixels=(600, 600),
           point_color=cs_j(),
           no_ticks=(7, 7),
           ticks_sigdigits=2)
```