### PR TITLE
fix x and y axes are switched

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -10,9 +10,9 @@
 
   seriestype := :heatmap
   xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
-             round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[1]), sigdigits=ticks_sigdigits))
+             round.(LinRange(real(z_lowerright), real(z_upperleft), no_ticks[1]), sigdigits=ticks_sigdigits))
   yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
-             reverse!(round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[2]), sigdigits=ticks_sigdigits)))
+             reverse!(round.(LinRange(imag(z_upperleft), imag(z_lowerright), no_ticks[2]), sigdigits=ticks_sigdigits)))
 
   img
 end


### PR DESCRIPTION
The x and y axes ticks labels were switched. I think this should fix it.