### PR TITLE
Fix direction of the axes 

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -10,9 +10,9 @@
 
   seriestype := :heatmap
   xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
-             round.(LinRange(real(z_lowerright), real(z_upperleft), no_ticks[1]), sigdigits=ticks_sigdigits))
+             round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits))
   yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
-             reverse!(round.(LinRange(imag(z_upperleft), imag(z_lowerright), no_ticks[2]), sigdigits=ticks_sigdigits)))
+             reverse!(round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
 
   img
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -10,9 +10,9 @@
 
   seriestype := :heatmap
   xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
-             round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits))
+            reverse!(round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits)))
   yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
-             reverse!(round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
+            (round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
 
   img
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -10,9 +10,9 @@
 
   seriestype := :heatmap
   xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
-            reverse!(round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits)))
+             round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits))
   yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
-            (round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
+             reverse!(round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
 
   img
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -10,9 +10,9 @@
 
   seriestype := :heatmap
   xticks := (LinRange(0, no_pixels[1], no_ticks[1]), 
-             round.(LinRange(real(z_upperleft), real(z_lowerright), no_ticks[1]), sigdigits=ticks_sigdigits))
+            reverse!(round.(LinRange(real(z_lowerright), real(z_upperleft), no_ticks[1]), sigdigits=ticks_sigdigits)))
   yticks := (LinRange(0, no_pixels[2], no_ticks[2]), 
-             reverse!(round.(LinRange(imag(z_lowerright), imag(z_upperleft), no_ticks[2]), sigdigits=ticks_sigdigits)))
+             (round.(LinRange(imag(z_upperleft), imag(z_lowerright), no_ticks[2]), sigdigits=ticks_sigdigits)))
 
   img
 end


### PR DESCRIPTION
This fixes the direction of the axes of the phaseplot function

**Before**

![before](https://user-images.githubusercontent.com/42966414/161369110-f63aa6a0-3f75-4e93-9658-9bc422aca1ab.png)

**After**

![after](https://user-images.githubusercontent.com/42966414/161369133-eb7b4630-6aa7-46ab-a6b8-1d43d50802b0.png)

